### PR TITLE
Add getter and setter method for redis.pool object

### DIFF
--- a/redis_cacher.go
+++ b/redis_cacher.go
@@ -301,3 +301,12 @@ func (c *RedisCacher) registerGobConcreteType(value interface{}) error {
 	}
 	return nil
 }
+
+func (c *RedisCacher) GetPool() (*redis.Pool, error) {
+	return c.pool,nil
+}
+
+func (c *RedisCacher) SetPool(pool *redis.Pool) {
+	c.pool = pool
+}
+


### PR DESCRIPTION
Fixed to reuse the objects created by this method in other packages.

We also considered the case of setting objects created with methods of other packages with the opposite pattern.

Specifically, I'd like to specify pool with redisstore.NewRediStoreWithPool ().

https://github.com/boj/redistore